### PR TITLE
fix "no_color!" command

### DIFF
--- a/lib/minitest/summarize_reporter.rb
+++ b/lib/minitest/summarize_reporter.rb
@@ -34,7 +34,7 @@ module Minitest
     end
 
     def self.color?
-      @color ||= true
+      @color
     end
 
     def initialize(io)
@@ -43,6 +43,7 @@ module Minitest
       @io          = io
       @summary     = {}
       @last_length = 0
+      @color       = true
 
       SUMMARY_LABELS.keys.each { |key| @summary[key] = 0 }
     end


### PR DESCRIPTION
`@color ||= true` will always evaluate to true, making "no_color!" have no effect. Replaced the fallback with an initialisation in the constructor.